### PR TITLE
Motifclasses enhancement

### DIFF
--- a/tobias/utils/motifs.py
+++ b/tobias/utils/motifs.py
@@ -1115,6 +1115,12 @@ class OneMotif:
 
 		return OneMotif(motifid=motifid, counts=[motif.counts[base] for base in ["A", "C", "G", "T"]], name=name)
 
+	def __repr__(self):
+		"""
+		OneMotif representation.
+		"""
+		return f"<OneMotif: {self.id}{' ' + self.name if len(self.name) > 0 else ''}>"
+
 
 ###########################################################
 

--- a/tobias/utils/motifs.py
+++ b/tobias/utils/motifs.py
@@ -593,6 +593,12 @@ class MotifList(list):
 
 		return MotifList([motif.get_reverse() for motif in self])
 
+	def __add__(self, other):
+		"""
+		Enable + operator to return MotifList.
+		"""
+		return MotifList(list(self) + list(other))
+
 #--------------------------------------------------------------------------------------------------------#
 def gimmemotif_to_onemotif(gimmemotif_obj):
 	""" Convert gimmemotif object to OneMotif object """
@@ -1108,6 +1114,7 @@ class OneMotif:
 			motif = motifs.read(handle, "sites")
 
 		return OneMotif(motifid=motifid, counts=[motif.counts[base] for base in ["A", "C", "G", "T"]], name=name)
+
 
 ###########################################################
 

--- a/tobias/utils/motifs.py
+++ b/tobias/utils/motifs.py
@@ -1088,6 +1088,27 @@ class OneMotif:
 
 		return self
 
+	@staticmethod
+	def from_fasta(fasta, motifid, name=None):
+		"""
+		Create motif from fasta.
+		Will use captital letters as motif sites (see JASPAR sites format).
+
+		Parameters:
+			fasta (string): Path to fasta file.
+
+			motifid (string): Unique id of the motif.
+
+			name (string): Name of the motif. Defaults to 'None'.
+
+		Returns:
+			OneMotif object
+		"""
+		with open(fasta) as handle:
+			motif = motifs.read(handle, "sites")
+
+		return OneMotif(motifid=motifid, counts=[motif.counts[base] for base in ["A", "C", "G", "T"]], name=name)
+
 ###########################################################
 
 def get_motif_format(content):


### PR DESCRIPTION
- Implemented `OneMotif.from_fasta` to create Motifs from fasta file.

- Implemented `+` operator for MotifList so that `motiflist + motiflist2` will return a MotifList object rather than a list.

- added `OneMotif.__repr__`, changes object representation from `<OneMotif object at [POS]>` to `<OneMotif: [ID] [NAME]>`
  e.g. `<OneMotif object at 0x7f2ee22da8e0>` -> `<OneMotif: AATCCAATCGCGCGGAACTT MEME-1>`