### PR TITLE
gimmemotifs 0.17.0 issue

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 ## 0.13.3 (in progress)
 - Fix of bug in utilities:match_lists leading to false list-to-list assignment in PlotChanges (#110)
+- Fixed bug in creating gimmemotifs object
+- Integrated checks related to gimmemotifs, pandas and python versions in ClusterMotifs
 
 ## 0.13.2 (2021-12-21)
 - Fix for bug introduced in 0.13.1 - faulty reading of motifs from .meme files

--- a/tobias/parsers.py
+++ b/tobias/parsers.py
@@ -508,7 +508,7 @@ def add_motifclust_arguments(parser):
 	
 	optional = parser.add_argument_group('Optional arguments')
 	optional.add_argument("-t", "--threshold", metavar="", help="Clustering threshold (Default = 0.3)", type=float, default=0.3)  
-	optional.add_argument('--dist_method', metavar="", help="Method for calculating similarity between motifs (default: pcc)", choices=["pcc", "seqcor", "ed", "distance", "wic", "chisq", "akl", "sdd"], default="pcc")
+	optional.add_argument('--dist_method', metavar="", help="Method for calculating similarity between motifs (default: pcc)", choices=["pcc", "seqcor", "wic", "akl"], default="pcc") 
 	optional.add_argument('--clust_method', metavar="", help="Method for clustering (See: https://docs.scipy.org/doc/scipy/reference/generated/scipy.cluster.hierarchy.linkage.html)", default="average", choices=["single","complete","average","weighted","centroid","median","ward"])
 	optional.add_argument("-a", "--cons_format", metavar="", choices= ['meme', 'pfm', 'jaspar'], help="Format of consensus motif file [‘meme’, 'pfm', 'jaspar'] (Default: jaspar)", default="jaspar")
 	optional.add_argument("-p", "--prefix", metavar="", help="Output prefix (default: 'motif_comparison')", default="motif_comparison")

--- a/tobias/tools/motif_clust.py
+++ b/tobias/tools/motif_clust.py
@@ -340,7 +340,7 @@ def run_motifclust(args):
 
 	consensus_motifs = MotifList()
 	for cluster_id in clusters:
-		consensus = clusters[cluster_id].create_consensus() 	#MotifList object with create_consensus method
+		consensus = clusters[cluster_id].create_consensus(metric=args.dist_method) 	#MotifList object with create_consensus method
 		consensus.id = cluster_id if len(clusters[cluster_id]) > 1 else clusters[cluster_id][0].id 	#set original motif id if cluster length = 1
 
 		consensus_motifs.append(consensus)

--- a/tobias/tools/motif_clust.py
+++ b/tobias/tools/motif_clust.py
@@ -24,6 +24,9 @@ import itertools
 import warnings
 from Bio import motifs
 from matplotlib import pyplot as plt
+from packaging import version
+import pkg_resources
+import platform
 
 from scipy.cluster.hierarchy import dendrogram, linkage, fcluster
 import scipy.spatial.distance as ssd
@@ -270,12 +273,39 @@ def run_motifclust(args):
 		from gimmemotifs.motif import Motif
 		from gimmemotifs.comparison import MotifComparer
 		sns.set_style("ticks")	#set style back to ticks, as this is set globally during gimmemotifs import
+
 	except ModuleNotFoundError:
 		logger.error("MotifClust requires the python package 'gimmemotifs'. You can install it using 'pip install gimmemotifs' or 'conda install gimmemotifs'.")
 		sys.exit(1)
+
+	except ImportError as e: #gimmemotifs was installed, but there was an error during import
+		
+		pandas_version = pd.__version__
+		python_version = platform.python_version()
+
+		if e.name == "collections" and (version.parse(python_version) >= version.parse("3.10.0")): #collections error from norns=0.1.5 and from other packages on python=3.10
+			logger.error("Due to package dependency errors, 'TOBIAS ClusterMotifs' is not available for python>=3.10. Current python version is '{0}'. Please downgrade python in order to use this tool.".format(python_version))
+			sys.exit(1)
+
+		elif e.name == "pandas.core.indexing" and (version.parse(pandas_version) >= version.parse("1.3.0")):
+			logger.error("Package 'gimmemotifs' version < 0.17.0 requires 'pandas' version < 1.3.0. Current pandas version is {0}.".format(pandas_version))
+			sys.exit(1) 
+		
+		else: #other import error
+			logger.error("Tried to import package 'gimmemotifs' but failed with error: '{0}'".format(repr(e)))
+			logger.error("Traceback:")
+			raise e
+
 	except Exception as e:
 		logger.error("Tried to import package 'gimmemotifs' but failed with error: '{0}'".format(repr(e)))
 		logger.error("Please check that 'gimmemotifs' was successfully installed.")
+		sys.exit(1)
+	
+	#Check gimmemotifs version vs. metric given
+	import gimmemotifs
+	gimme_version = gimmemotifs.__version__
+	if gimme_version == "0.17.0" and args.dist_method in ["pcc", "akl"]:
+		logger.warning("The dist_method given ('{0}') is invalid for gimmemotifs version 0.17.0. Please choose another --dist_method. See also: https://github.com/vanheeringen-lab/gimmemotifs/issues/243".format(args.dist_method))
 		sys.exit(1)
 
 	#---------------------------------------- Reading motifs from file(s) -----------------------------------#
@@ -315,7 +345,7 @@ def run_motifclust(args):
 	#---------------------------------------- Motif clustering ----------------------------------------------#
 	logger.info("Clustering motifs")
 
-	clusters = motif_list.cluster(threshold=args.threshold, metric = args.dist_method, clust_method=args.clust_method)
+	clusters = motif_list.cluster(threshold=args.threshold, metric=args.dist_method, clust_method=args.clust_method)
 	logger.stats("- Identified {0} clusters".format(len(clusters)))
 	
 	#Write out overview of clusters

--- a/tobias/tools/motif_clust.py
+++ b/tobias/tools/motif_clust.py
@@ -25,7 +25,6 @@ import warnings
 from Bio import motifs
 from matplotlib import pyplot as plt
 from packaging import version
-import pkg_resources
 import platform
 
 from scipy.cluster.hierarchy import dendrogram, linkage, fcluster

--- a/tobias/utils/motifs.py
+++ b/tobias/utils/motifs.py
@@ -855,12 +855,10 @@ class OneMotif:
 			motif_rows.append(row)
 
 		# generate gimmemotif motif instance
-		self.gimme_obj = Motif()
+		self.gimme_obj = Motif(pfm=motif_rows)
   
 		# populate empty object
 		self.gimme_obj.id = self.id + " " + self.name
-		self.gimme_obj.pfm = motif_rows
-		self.gimme_obj.pwm = self.gimme_obj.pfm_to_pwm(motif_rows)
 
 		return(self)
 		

--- a/tobias/utils/motifs.py
+++ b/tobias/utils/motifs.py
@@ -74,6 +74,17 @@ def float_to_int(afloat):
 	else:
 		pass #if afloat is a string with multiple "."'s
 
+def is_symmetric(matrix):
+	""" Check if a matrix is symmetric around the diagonal """
+
+	s = matrix.shape
+	if s[0] != s[1]:
+		b = False #Not diagonal since rows != cols
+	else:
+		b = np.allclose(matrix, matrix.T, equal_nan=True)
+
+	return(b)
+
 #----------------------------------------------------------------------------------------#
 #List of OneMotif objects
 class MotifList(list):
@@ -490,7 +501,10 @@ class MotifList(list):
 		self.similarity_matrix = generate_similarity_matrix(score_dict)
 
 		# Clustering
-		vector = ssd.squareform(self.similarity_matrix.to_numpy())
+		if is_symmetric(self.similarity_matrix) == True: #is matrix is symmetric, checks are not necessary
+			vector = ssd.squareform(self.similarity_matrix, checks=False)
+		else:
+			vector = ssd.squareform(self.similarity_matrix, checks=True)
 		self.linkage_mat = linkage(vector, method=clust_method)
 
 		# Flatten clusters
@@ -504,9 +518,10 @@ class MotifList(list):
 
 		return cluster_dict
 
-	def create_consensus(self):
+	def create_consensus(self, metric="pcc"):
 		""" Create consensus motif from MotifList """
 
+		from gimmemotifs.motif import Motif
 		from gimmemotifs.comparison import MotifComparer
 
 		self = [motif.get_gimmemotif() if motif.gimme_obj is None else motif for motif in self]	#fill in gimme_obj if it is not found
@@ -517,7 +532,7 @@ class MotifList(list):
 			mc = MotifComparer()
 
 			#Initialize score_dict
-			score_dict = mc.get_all_scores(motif_list, motif_list, match = "total", metric = "pcc", combine = "mean")
+			score_dict = mc.get_all_scores(motif_list, motif_list, match="total", metric=metric, combine="mean")
 
 			while not consensus_found:
 
@@ -525,7 +540,7 @@ class MotifList(list):
 				best_similarity_motifs = sorted(find_best_pair(motif_list, score_dict))   #indices of most similar motifs in cluster_motifs
 
 				#Merge
-				new_motif = merge_motifs(motif_list[best_similarity_motifs[0]], motif_list[best_similarity_motifs[1]]) 
+				new_motif = merge_motifs(motif_list[best_similarity_motifs[0]], motif_list[best_similarity_motifs[1]], metric=metric) 
 
 				del(motif_list[best_similarity_motifs[1]])
 				motif_list[best_similarity_motifs[0]] = new_motif
@@ -539,12 +554,15 @@ class MotifList(list):
 					score_dict[new_motif.id] = score_dict.get(new_motif.id, {})
 
 					for m in motif_list:
-						score_dict[new_motif.id][m.id] = mc.compare_motifs(new_motif, m, metric= "pcc")
-						score_dict[m.id][new_motif.id] = mc.compare_motifs(m, new_motif, metric = "pcc")
+						score_dict[new_motif.id][m.id] = mc.compare_motifs(new_motif, m, metric=metric)
+						score_dict[m.id][new_motif.id] = mc.compare_motifs(m, new_motif, metric=metric)
 	
 		#Round pwm values
 		gimmemotif_consensus = motif_list[0]
-		gimmemotif_consensus.pwm = [[round(f, 5) for f in l] for l in gimmemotif_consensus.pwm]
+		gimme_id = gimmemotif_consensus.id
+		pwm = [[round(f, 5) for f in l] for l in gimmemotif_consensus.pwm]
+		gimmemotif_consensus = Motif(pwm) #create new motif with the rounded values
+		gimmemotif_consensus.id = gimme_id
 
 		#Convert back to OneMotif obj
 		onemotif_consensus = gimmemotif_to_onemotif(gimmemotif_consensus)
@@ -667,7 +685,7 @@ def generate_similarity_matrix(score_dict):
 	return dataframe
 
 #--------------------------------------------------------------------------------------------------------#
-def merge_motifs(motif_1, motif_2):
+def merge_motifs(motif_1, motif_2, metric="pcc"):
 	"""Creates the consensus motif from two provided motifs, using the pos and orientation calculated by gimmemotifs get_all_scores()
 
 	Parameter:
@@ -684,8 +702,8 @@ def merge_motifs(motif_1, motif_2):
 	from gimmemotifs.comparison import MotifComparer
 
 	mc = MotifComparer()
-	_, pos, orientation = mc.compare_motifs(motif_1, motif_2, metric= "pcc")
-	consensus = motif_1.average_motifs(motif_2, pos = pos, orientation = orientation)
+	_, pos, orientation = mc.compare_motifs(motif_1, motif_2, metric=metric)
+	consensus = motif_1.average_motifs(motif_2, pos=pos, orientation=orientation)
 	consensus.id = motif_1.id + "+" + motif_2.id
 
 	return consensus

--- a/tobias/utils/utilities.py
+++ b/tobias/utils/utilities.py
@@ -359,7 +359,7 @@ class Progress:
 def flatten_list(lst):
 
 	for element in lst:
-		if isinstance(element, collections.Iterable) and not isinstance(element, (str, bytes)):
+		if hasattr(element, "__iter__") and not isinstance(element, (str, bytes)):
 			yield from flatten_list(element)
 		else:
 			yield element


### PR DESCRIPTION
Starting with version 0.17.0 gimmemotifs renamed `pfm_to_pwm` to `pfm_to_ppm`. To make the code version independent the gimmemotif object is now initialized with count matrix. This will trigger calculation of all needed matrices formerly added in manually.