### PR TITLE
Update merge_pdfs.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(name='tobias',
 			'matplotlib>=2',
 			'scikit-learn',
 			'pandas',
-			'pypdf2',
+			'pypdf2>=1.28.0',
 			'xlsxwriter',
 			'adjustText',
 			'pyBigWig>=0.3',		#to use values(numpy=True)

--- a/tobias/tools/merge_pdfs.py
+++ b/tobias/tools/merge_pdfs.py
@@ -8,7 +8,7 @@ Small utility for mering pdfs
 @license: MIT
 """
 
-from PyPDF2 import PdfFileMerger, PdfFileReader
+from PyPDF2 import PdfMerger, PdfReader
 import argparse
 import sys
 import os
@@ -30,10 +30,10 @@ def run_mergepdf(args):
 
 	#Join pdfs
 	print("Starting to merge PDFs")
-	merger = PdfFileMerger(strict=False)
+	merger = PdfMerger(strict=False)
 	for pdf in args.input:
 		if os.stat(pdf).st_size != 0:	#only join files containing plots
-			merger.append(PdfFileReader(pdf))
+			merger.append(PdfReader(pdf))
 	
 	print("Writing merged file: {0}".format(args.output))
 	merger.write(args.output)


### PR DESCRIPTION
Switched from using PdfFileMerger (deprecated) To PdfMerger as recommended in PyPDF2 version 3.0.0 and above. PdfFileReader was switched to PdfReader for the same reason.