### PR TITLE
Release 0.17.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 dist/
 *.egg
 *.egg-info
+*.so

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+## 0.17.2 (in Progress)
+- disabled p-value highlighting in volcano plots if no p-values fulfill conditions (allows better intvestigation of the reasons for that if BINDetect does not crash because of it)
+
 ## 0.17.1 (2024-12-13)
 - fixed a bug caused by usage of deprecated cython data types that arose after the update to numpy>=2
 - fixed a bug with SubMerge when input region files had more columns than expected

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 ## 0.17.2 (in Progress)
 - disabled p-value highlighting in volcano plots if no p-values fulfill conditions (allows better intvestigation of the reasons for that if BINDetect does not crash because of it)
+- Removed sklearn-contrib-lightning as its causing version conflicts and is not longer used anyway
+- Removed 'gimmemotifs' from the enviroment YAML like already done for the setup.py in 0.11.0 (warning added already at this point)
+- Fixed link to the sc_framework notebook
 
 ## 0.17.1 (2024-12-13)
 - fixed a bug caused by usage of deprecated cython data types that arose after the update to numpy>=2

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ATAC-seq (Assay for Transposase-Accessible Chromatin using high-throughput seque
 
 For information on each tool, please see the [wiki](https://github.com/loosolab/TOBIAS/wiki/).
 
-Although TOBIAS was originally developed for bulk experiments, it can also be applied to single-cell resolution data. To do that, we recommend generating individual pseudobulk BAM files from scATAC-seq cell type clusters. This can be done using the [sc-framework](https://github.com/loosolab/SC-Framework), which also contains a [notebook specifically designed for scATAC-seq TOBIAS analyses](https://github.com/loosolab/SC-Framework/blob/main/atac_analysis/notebooks/0A_tobias.ipynb). It is important to note that the quality of the single cells and the cell clustering is paramount for achieving a clean footprinting analysis. Therefore, we recommend using [PEAKQC](https://github.com/loosolab/PEAKQC) for cell quality assessment beforehand.
+Although TOBIAS was originally developed for bulk experiments, it can also be applied to single-cell resolution data. To do that, we recommend generating individual pseudobulk BAM files from scATAC-seq cell type clusters. This can be done using the [sc-framework](https://github.com/loosolab/SC-Framework), which also contains a [notebook](https://github.com/loosolab/SC-Framework/blob/main/atac_analysis/notebooks/0A_tobias.ipynb) specifically designed for scATAC-seq TOBIAS analyses. It is important to note that the quality of the single cells and the cell clustering is paramount for achieving a clean footprinting analysis. Therefore, we recommend using [PEAKQC](https://github.com/loosolab/PEAKQC) for cell quality assessment beforehand.
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ATAC-seq (Assay for Transposase-Accessible Chromatin using high-throughput seque
 
 For information on each tool, please see the [wiki](https://github.com/loosolab/TOBIAS/wiki/).
 
-Although TOBIAS was originally developed for bulk experiments, it can also be applied to single-cell resolution data. To do that, we recommend generating individual pseudobulk BAM files from scATAC-seq cell type clusters. This can be done using the [sc-framework](https://github.com/loosolab/SC-Framework), which also contains a [notebook specifically designed for scATAC-seq TOBIAS analyses](https://github.com/loosolab/SC-Framework/blob/main/atac_analysis/notebooks/05_tobias.ipynb). It is important to note that the quality of the single cells and the cell clustering is paramount for achieving a clean footprinting analysis. Therefore, we recommend using [PEAKQC](https://github.com/loosolab/PEAKQC) for cell quality assessment beforehand.
+Although TOBIAS was originally developed for bulk experiments, it can also be applied to single-cell resolution data. To do that, we recommend generating individual pseudobulk BAM files from scATAC-seq cell type clusters. This can be done using the [sc-framework](https://github.com/loosolab/SC-Framework), which also contains a [notebook specifically designed for scATAC-seq TOBIAS analyses](https://github.com/loosolab/SC-Framework/blob/main/atac_analysis/notebooks/0A_tobias.ipynb). It is important to note that the quality of the single cells and the cell clustering is paramount for achieving a clean footprinting analysis. Therefore, we recommend using [PEAKQC](https://github.com/loosolab/PEAKQC) for cell quality assessment beforehand.
 
 Installation
 ------------

--- a/tobias/tools/bindetect.py
+++ b/tobias/tools/bindetect.py
@@ -753,7 +753,13 @@ def run_bindetect(args):
 		names = info_table["output_prefix"]
 		changes = info_table[base + "_change"].astype(float)
 		pvalues = info_table[base + "_pvalue"].astype(float)
-		pval_min = np.percentile(pvalues[pvalues > 0], 5)	#5% smallest pvalues
+
+		filtered_pvalues = pvalues[pvalues > 0]
+		if len(filtered_pvalues) >= 1:
+			pval_min = np.percentile(filtered_pvalues, 5)  #5% smallest pvalues
+		else:
+			pval_min = 1.0  # workaround for the index error in issue #294
+
 		change_min, change_max = np.percentile(changes, [5, 95])	#5% smallest and largest changes
 		
 		#Add "highlighted" information to info_table

--- a/tobias_env.yaml
+++ b/tobias_env.yaml
@@ -22,8 +22,5 @@ dependencies:
   - pyyaml>=5.1
   - boto3
   - adjustText>=0.8
-  - sklearn-contrib-lightning
   - xlsxwriter
   - pip
-  - pip:
-    - gimmemotifs


### PR DESCRIPTION
This will solve multiple minor issues including version conflicts with python >= 3.12. 

CHANGES:
  - disabled p-value highlighting in volcano plots if no p-values fulfill conditions (allows better intvestigation of the reasons for that if BINDetect does not crash because of it)
  - Removed sklearn-contrib-lightning as its causing version conflicts and is not longer used anyway
  - Removed 'gimmemotifs' from the enviroment YAML like already done for the setup.py in 0.11.0 (warning added already at this point)
  - Fixed link to the sc_framework notebook