### PR TITLE
Revise Python publish workflow for building wheels

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,15 +22,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
+      - name: Build wheels                        
+        uses: pypa/cibuildwheel@v3                
+        env:                                      
+          CIBW_BUILD: >-                          
+            cp310-manylinux_x86_64
+            cp311-manylinux_x86_64
+            cp312-manylinux_x86_64
+            cp313-manylinux_x86_64
+            cp314-manylinux_x86_64
 
-      - name: Build release distributions
-        run: |
-          # NOTE: put your own distribution build steps here.
-          python -m pip install build
-          python -m build
+      - uses: actions/setup-python@v5              
+        with:
+          python-version: "3.14"                 
+
+      - name: Build source distribution           
+        run: |                                    
+          python -m pip install --upgrade build   
+          python -m build --sdist                 
+
+      - name: Collect distributions               
+        run: |                                    
+          mkdir -p dist                           
+          cp wheelhouse/*.whl dist/               
 
       - name: Upload distributions
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Updated Python setup and build steps in CI workflow. Manylinux should be used as build enviroment.